### PR TITLE
Added Load_PACCAR_Data_withCleaning

### DIFF
--- a/Load_PACCAR_Data_withCleaning.ipynb
+++ b/Load_PACCAR_Data_withCleaning.ipynb
@@ -1,0 +1,488 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function, division\n",
+    "import time, os\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "import networkx as nx\n",
+    "import pandas\n",
+    "\n",
+    "%matplotlib inline\n",
+    "plt.rcParams['figure.figsize'] = (10.0, 8.0) # set default size of plots\n",
+    "plt.rcParams['image.interpolation'] = 'nearest'\n",
+    "plt.rcParams['image.cmap'] = 'gray'\n",
+    "\n",
+    "# for auto-reloading external modules\n",
+    "# see http://stackoverflow.com/questions/1907993/autoreload-of-modules-in-ipython\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# 6/14/2016 20:17:07\n",
+    "s_to_date = lambda x: pandas.to_datetime(x, format='%m/%d/%Y %H:%M:%S')\n",
+    "snapshots_df = pandas.read_csv('/home/cs231n/data/Field_Snaps_With_warranty.txt', converters={'Event DateTime':s_to_date})\n",
+    "#snapshots_df = pandas.read_csv('Field Snaps - With warranty.txt', converters={'Event DateTime':s_to_date})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# 2/3/2016\n",
+    "r_to_date = lambda x: pandas.to_datetime(x, format='%m/%d/%Y')\n",
+    "repairs_df = pandas.read_csv('/home/cs231n/data/repairs.csv', converters={'Rpr_Dt':r_to_date})\n",
+    "#repairs_df = pandas.read_csv('repairs.csv', converters={'Rpr_Dt':r_to_date})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(853, 15)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "selected_repairs = repairs_df[[\n",
+    " 'Chassis\\nReference\\nNumber',\n",
+    " 'Model Vehicle',\n",
+    " 'Build_Dt',\n",
+    " 'Dlvry_Dt',\n",
+    " 'In Service Date',\n",
+    " 'Miles',\n",
+    " 'Rpr_Dt',\n",
+    " 'ATA3',\n",
+    " 'ATA3Desc',\n",
+    " 'ATA6',\n",
+    " 'ATA6Desc',\n",
+    " 'ATA9',\n",
+    " 'ATA9Desc',\n",
+    " 'Fail Type',\n",
+    " 'Repair Cost']]\n",
+    "selected_repairs = selected_repairs[selected_repairs['Chassis\\nReference\\nNumber'].notnull()] \n",
+    "selected_repairs.shape  #before: 1128x15, after: 853x15"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# To shift below after selected_repairs is cleaned\n",
+    "# ZY: 'Repair Cost' category is 'high ', instead of 'high'\n",
+    "#high_repairs = selected_repairs[selected_repairs['Repair Cost'].isin(['medium', 'high ', 'very high'])]\n",
+    "#veh_ids = high_repairs['Chassis\\nReference\\nNumber'].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# ZY: is this not needed?\n",
+    "#selected_repairs = high_repairs['Chassis\\nReference\\nNumber'].isin(veh_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#selected_snapshots = snapshots_df['Veh Ref ID'].isin(veh_ids)  #ZY: is this not needed?\n",
+    "selected_snapshots = snapshots_df[['Veh Ref ID',\n",
+    " 'Event DateTime',\n",
+    " 'Event Type Description',\n",
+    " 'Acc Pedal Position',\n",
+    " 'Ambient Air Temp',\n",
+    " 'Barometric Press',\n",
+    " 'Brake Switch',\n",
+    " 'Bus Utilization',\n",
+    " 'Cat Intake Gas Temp',\n",
+    " 'Cat Outlet Gas Temp',\n",
+    " 'Clutch Switch',\n",
+    " 'Cmd Eng Fuel Press',\n",
+    " 'Cruise Status',\n",
+    " 'Dpf Regen Inhibit Sw',\n",
+    " 'Dpf Thermal Mngmnt',\n",
+    " 'Drvr Demand Torque',\n",
+    " 'Eng Air Flow Rate',\n",
+    " 'Eng Avg Fuel Econ',\n",
+    " 'Eng Coolant Level',\n",
+    " 'Eng Coolant Temp',\n",
+    " 'Eng Demand Torque',\n",
+    " 'Eng DPF Intake Press',\n",
+    " 'Eng Egr Valve Pos',\n",
+    " 'Eng Exhaust Gas Temp',\n",
+    " 'Eng Fuel Del Press',\n",
+    " 'EngFuelTemp1',\n",
+    " 'Engine Speed',\n",
+    " 'Eng Man Abs Pressure',\n",
+    " 'Eng Oil Pressure',\n",
+    " 'EngInjRail1Press',\n",
+    " 'EngIntakeMan1Temp',\n",
+    " 'EngOilTemp1',\n",
+    " 'Eng Percent Torque',\n",
+    " 'EngTurbo1Boost',\n",
+    " 'EngTurbo1Pos',\n",
+    " 'EngTurbo1Speed',\n",
+    " 'Event - All Lamps On Time Hr',\n",
+    " 'Event - Amber Lamp Time Hr',\n",
+    " 'Event - Mil Lamp Time Hr',\n",
+    " 'Event - Red Lamp Time Hr',\n",
+    " 'Exhaust Tank Level',\n",
+    " 'Exhaust Tank Temp',\n",
+    " 'Fan Speed',\n",
+    " 'Keyswitch Bat Pot',\n",
+    " 'Part Trap Diff Press',\n",
+    " 'Part Trap Out Temp',\n",
+    " 'Scr Intake Gas Temp',\n",
+    " 'Scr Outlet Gas Temp',\n",
+    " 'Vehicle Speed',\n",
+    " 'Population',\n",
+    " 'DTCID',\n",
+    " 'Trip Distance',\n",
+    " 'Trip Idle Time',\n",
+    " 'Trip Run Time',\n",
+    " 'Altitude',\n",
+    " 'Engine Start Ambient',\n",
+    " 'Engine Start Coolant',\n",
+    " 'Ignition Cycle Counter',\n",
+    " 'Latitude',\n",
+    " 'Longitude',\n",
+    " 'Lifetime Idle Hours',\n",
+    " 'Lifetime Idle Fuel',\n",
+    " 'Lifetime Fuel',\n",
+    " 'Lifetime Distance',\n",
+    " 'Lifetime Engine Hours']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Eng Avg Fuel Econ         0.001537\n",
+       "Eng DPF Intake Press      0.000031\n",
+       "Eng Fuel Del Press        0.000062\n",
+       "EngInjRail1Press          0.000052\n",
+       "EngIntakeMan1Temp         0.000003\n",
+       "Fan Speed                 0.000003\n",
+       "Ignition Cycle Counter    0.691675\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#---------------------------------------\n",
+    "# Data-Cleaning - selected_snapshots (part 1)\n",
+    "#---------------------------------------\n",
+    "# drop duplicate rows\n",
+    "selected_snapshots = selected_snapshots.drop_duplicates() \n",
+    "selected_snapshots.shape  #before: 1581892 x 65, after removing duplicate rows: 1015071 x 65\n",
+    "\n",
+    "# Checking for null entries\n",
+    "nullTable = selected_snapshots.isnull().sum()\n",
+    "nullTable[nullTable > 0]/len(selected_snapshots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Series([], dtype: float64)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#---------------------------------------\n",
+    "# Data-Cleaning - selected_snapshots (part 2)\n",
+    "#---------------------------------------\n",
+    "# Remove column 'Ignition Cycle Counter' ~69.2% missing values  --> 101571 x 64\n",
+    "selected_snapshots = selected_snapshots.drop('Ignition Cycle Counter', axis=1) \n",
+    "\n",
+    "# Impute missing values using mean value, i.e. E(value | vehicle id)\n",
+    "fields = ['Eng Avg Fuel Econ', 'Eng DPF Intake Press', 'Eng Fuel Del Press', 'EngInjRail1Press', 'EngIntakeMan1Temp', 'Fan Speed']\n",
+    "for f in fields:\n",
+    "    noData_vehID = selected_snapshots[selected_snapshots[f].isnull()]['Veh Ref ID'].unique()\n",
+    "    for veh_id in noData_vehID:\n",
+    "        # compute mean value of field f for that vehicle\n",
+    "        value = selected_snapshots[selected_snapshots['Veh Ref ID'] ==  veh_id][f].mean()\n",
+    "        \n",
+    "        #update missing value with mean value\n",
+    "        idx = selected_snapshots.index[selected_snapshots[f].isnull()]\n",
+    "        selected_snapshots.loc[idx,f] = value\n",
+    "\n",
+    "nullTable = selected_snapshots.isnull().sum()\n",
+    "nullTable[nullTable > 0]/len(selected_snapshots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Chassis\\nReference\\nNumber    0\n",
+       "Model Vehicle                 0\n",
+       "Build_Dt                      0\n",
+       "Dlvry_Dt                      0\n",
+       "In Service Date               0\n",
+       "Miles                         0\n",
+       "Rpr_Dt                        0\n",
+       "ATA3                          0\n",
+       "ATA3Desc                      0\n",
+       "ATA6                          0\n",
+       "ATA6Desc                      1\n",
+       "ATA9                          0\n",
+       "ATA9Desc                      0\n",
+       "Fail Type                     4\n",
+       "Repair Cost                   0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#---------------------------------------\n",
+    "# Data-Cleaning - selected_repairs\n",
+    "#---------------------------------------\n",
+    "#filter away vehicles that broke down before delivery & service (veh 616: accident during undecking) \n",
+    "selected_repairs = selected_repairs[selected_repairs['Miles']>0]   \n",
+    "selected_repairs.shape   # before: 853x15, after: 852x15\n",
+    "\n",
+    "# identify and remove rows with no snapshot data prior to repair date\n",
+    "nodata_veh_repair = []\n",
+    "for veh_id in selected_repairs['Chassis\\nReference\\nNumber'].unique():\n",
+    "    v_snapshots = selected_snapshots[selected_snapshots['Veh Ref ID'] == veh_id].sort_values(by='Event DateTime')\n",
+    "    repairDate = (selected_repairs[selected_repairs['Chassis\\nReference\\nNumber']==veh_id]['Rpr_Dt'])    \n",
+    "    for r in repairDate:\n",
+    "        if len(v_snapshots[v_snapshots['Event DateTime']<=r]) == 0: #no snapshot data prior to repair date\n",
+    "            nodata_veh_repair.append({'Chassis\\nReference\\nNumber':veh_id,'Rpr_Dt':r})\n",
+    "            #remove that row in selected_repair\n",
+    "            idx = selected_repairs.index[(selected_repairs['Chassis\\nReference\\nNumber'] == veh_id) & (selected_repairs['Rpr_Dt'] == r)]\n",
+    "            selected_repairs = selected_repairs.drop(idx)\n",
+    "            \n",
+    "nodata_veh_repair = pandas.DataFrame(nodata_veh_repair)\n",
+    "selected_repairs.shape  # before: 852x15, after: 713x15\n",
+    "\n",
+    "# check for other null entries:\n",
+    "# ('Chasis\\nReference\\nNumber', 'ATA9', 'Rpr_Dt') has no null entries. Sufficient to link to snapshot data\n",
+    "selected_repairs.isnull().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# save cleaned data to pickle format for quick reloading in future\n",
+    "selected_snapshots.to_pickle('cleaned_selected_snapshots.pkl')\n",
+    "selected_repairs.to_pickle('cleaned_selected_repairs.pkl')\n",
+    "\n",
+    "# reload cleaned data\n",
+    "#selected_snapshots = pandas.read_pickle('cleaned_selected_snapshots.pkl')\n",
+    "#selected_repairs = pandas.read_pickle('cleaned_selected_repairs.pkl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# ZY: 'Repair Cost' category is 'high ', instead of 'high' (extra white-space)\n",
+    "high_repairs = selected_repairs[selected_repairs['Repair Cost'].isin(['medium', 'high ', 'very high'])]\n",
+    "veh_ids = high_repairs['Chassis\\nReference\\nNumber'].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_012_dates(end_date):\n",
+    "    ## split into 0 (10+), 1 (5-10), 2(0-5)\n",
+    "    two_end = end_date\n",
+    "    one_end = pandas.to_datetime(two_end) + pandas.DateOffset(days=-5)\n",
+    "    zero_end = one_end + pandas.DateOffset(days=-5)\n",
+    "    return (zero_end, one_end, two_end)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_repair_slices(veh_ids, snapshots, repairs, code='ATA9'):\n",
+    "    repair_slices = {}\n",
+    "    for veh_id in veh_ids:\n",
+    "        v_snapshots = snapshots[snapshots['Veh Ref ID'] == veh_id].sort_values(by='Event DateTime')\n",
+    "        v_repairs = repairs[repairs['Chassis\\nReference\\nNumber'] == veh_id].sort_values(by='Rpr_Dt')\n",
+    "\n",
+    "        start_date = pandas.to_datetime('1/1/2000') ## in past so first snapshot is captured\n",
+    "        event_dt_key = 'Event DateTime'\n",
+    "\n",
+    "        repair_slices[veh_id] = {}\n",
+    "        veh_slices = repair_slices[veh_id]\n",
+    "\n",
+    "        ## Best indicator of repair type is the ATA9 code\n",
+    "        ## Iterate over each repair type and append slices\n",
+    "        for repair_type, repair_group in v_repairs.groupby([code]):  #ZY: veh_repairs --> v_repairs\n",
+    "            start = start_date\n",
+    "            end = -1\n",
+    "\n",
+    "            ## dates of all of the repairs in that group\n",
+    "            repair_dates = repair_group.sort_values(by='Rpr_Dt')['Rpr_Dt']\n",
+    "            r_size = len(repair_dates)\n",
+    "\n",
+    "            ## for each repair type, grab slices of snapshots\n",
+    "            veh_slices_repair = {0:[],1:[],2:[]}\n",
+    "            for repair in repair_group.itertuples():\n",
+    "                end = repair[7] ##['Rpr_Dt']\n",
+    "\n",
+    "                (zero_end, one_end, two_end) = get_012_dates(end)\n",
+    "                \n",
+    "                # divide up snapshots into 0, 1, 2 slices\n",
+    "                two_mask = (v_snapshots[event_dt_key] > one_end) & (v_snapshots[event_dt_key] <= end)\n",
+    "                one_mask = (v_snapshots[event_dt_key] > zero_end) & (v_snapshots[event_dt_key] <= one_end)\n",
+    "                zero_mask = (v_snapshots[event_dt_key] >= start) & (v_snapshots[event_dt_key] <= zero_end)\n",
+    "                two_slices = v_snapshots.loc[two_mask]\n",
+    "                one_slices = v_snapshots.loc[one_mask]\n",
+    "                zero_slices = v_snapshots.loc[zero_mask]\n",
+    "\n",
+    "                if len(two_slices) > 0:\n",
+    "                    veh_slices_repair[2].append(two_slices)\n",
+    "                if len(one_slices) > 0:\n",
+    "                    veh_slices_repair[1].append(one_slices)\n",
+    "                if len(zero_slices) > 0:\n",
+    "                    veh_slices_repair[0].append(zero_slices)\n",
+    "\n",
+    "                ## reset start to end for next iteration\n",
+    "                start = end\n",
+    "            \n",
+    "            if len(veh_slices_repair[0]) > 0 or len(veh_slices_repair[1]) > 0 or len(veh_slices_repair[2]) > 0:\n",
+    "                veh_slices[repair_type] = veh_slices_repair\n",
+    "\n",
+    "    return repair_slices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "repair_slices_all = get_repair_slices(veh_ids, selected_snapshots, selected_repairs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Addition to Christy's code:
1. Data Cleaning - 'selected_snapshots'
- removed duplicate rows and check for missing values
- removed column 'Ignition Cycle Counter': ~69.2% missing values
- imputed missing values in other columns with E(value|vehicle ID)
2. Data Cleaning - 'selected_repairs'
- filter away the repair with 0 mileage (veh #616: damage to engine during undecking): i.e. sensor data will not help predict repair
- identify and remove repairs with no snapshot data prior to repair date: i.e. no sensor data to train for predicting the repair
- check for other null entries
3. Saved cleaned 'selected_snapshots' and 'selected_repairs' in pickle format for quick reloading in future 
4. Shifted code to filter high_repairs and veh_ids down to execute on the cleaned 'selected_repairs'
5. Edits
- selected_repair['Repair Cost'].isin(['medium', 'high', 'very high'])]:  'high' changed to 'high ' with a white-space behind
- get_repair_slices:
       for repair_type, repair_group in veh_repairs.groupby([code]):   'veh_repairs' changed to 'v_repairs'